### PR TITLE
Feat/6 모듈화

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -333,10 +333,10 @@ void handleCharCommand(char cmd) {
 void driveStop() {
     if (targetThrottle > 0.0f) {
         targetThrottle = -0.1f;
-        delay(100);
+        delay(500);
     } else {
         targetThrottle = 0.1f;
-        delay(100);
+        delay(500);
     }
     targetThrottle = 0.0f;
     steerCmd = 0.0f;
@@ -346,11 +346,11 @@ void driveForward() {
     if (digitalRead(leftMotor.bkPin) && digitalRead(rightMotor.bkPin)) {
         digitalWrite(leftMotor.bkPin, LOW); digitalWrite(rightMotor.bkPin, LOW);
     }
-    // if(!digitalRead(leftMotor.dirPin) && digitalRead(rightMotor.dirPin)) {
-    //     digitalWrite(leftMotor.bkPin, HIGH); digitalWrite(rightMotor.bkPin, HIGH);
-    //     Serial.println("Break and Forward!");
-    //     delay(100);
-    // }
+    if(!digitalRead(leftMotor.dirPin) && digitalRead(rightMotor.dirPin)) {
+        digitalWrite(leftMotor.bkPin, HIGH); digitalWrite(rightMotor.bkPin, HIGH);
+        Serial.println("Break and Forward!");
+        delay(500);
+    }
     digitalWrite(leftMotor.dirPin, HIGH); digitalWrite(rightMotor.dirPin, LOW);
     digitalWrite(leftMotor.bkPin, LOW); digitalWrite(rightMotor.bkPin, LOW);
     targetThrottle = constrain(targetThrottle + THROTTLE_STEP, 0.0f, FWD_SPEED);
@@ -360,11 +360,11 @@ void driveBackward() {
     if (digitalRead(leftMotor.bkPin) && digitalRead(rightMotor.bkPin)) {
         digitalWrite(leftMotor.bkPin, LOW); digitalWrite(rightMotor.bkPin, LOW);
     }
-    // if (digitalRead(leftMotor.dirPin) && !digitalRead(rightMotor.dirPin)) {
-    //     digitalWrite(leftMotor.bkPin, HIGH); digitalWrite(rightMotor.bkPin, HIGH);
-    //     Serial.println("Break and Backward!");
-    //     delay(100);
-    // }
+    if (digitalRead(leftMotor.dirPin) && !digitalRead(rightMotor.dirPin)) {
+        digitalWrite(leftMotor.bkPin, HIGH); digitalWrite(rightMotor.bkPin, HIGH);
+        Serial.println("Break and Backward!");
+        delay(500);
+    }
     digitalWrite(leftMotor.dirPin, LOW); digitalWrite(rightMotor.dirPin, HIGH);
     digitalWrite(leftMotor.bkPin, LOW); digitalWrite(rightMotor.bkPin, LOW);
     targetThrottle = BWD_SPEED;


### PR DESCRIPTION
## 연관된 이슈

> Closes:#6 

## 작업 내용

- PID, 입력 기반 필터링, 차동 조향 분배, Soft Start 등의 제어 로직을 활성/비활성화할 수 있도록 수정
  - 플래그를 통해 제어 가능
- 양쪽 모터 드라이버 DIR 단자에 같은 신호를 주면 반대로 도는 문제 발생
> ex) 왼쪽 LOW, 오른쪽 LOW이면 왼쪽 후진, 오른쪽 전진, 왼쪽 HIGH, 오른쪽 HIGH이면 왼쪽 전진, 오른쪽 후진하는 문제
- 따라서 각 모터의 DIR에 신호를 반대로 주도록 설정
- 전/후진 중 방향 전환시 급격한 변화 문제
> ex) 전진 중 후진하면 바로 반대 방향으로 속도를 유지한 채로 바뀌기에 차체와 모터에 무리를 줄 수 있음
- 따라서 DIR 변경 전 브레이크를 걸고 이후에 DIR에 신호를 인입하도록 수정